### PR TITLE
chore: release v0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.6](https://github.com/markhaehnel/bambulab/compare/v0.4.5...v0.4.6) - 2024-10-21
+
+### Other
+
+- *(deps)* bump serde_json from 1.0.129 to 1.0.132 ([#40](https://github.com/markhaehnel/bambulab/pull/40))
+
 ## [0.4.5](https://github.com/markhaehnel/bambulab/compare/v0.4.4...v0.4.5) - 2024-10-18
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "bambulab"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "futures",
  "nanoid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bambulab"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 repository = "https://github.com/markhaehnel/bambulab"
 authors = ["Mark Hähnel <hello@markhaehnel.de>"]


### PR DESCRIPTION
## 🤖 New release
* `bambulab`: 0.4.5 -> 0.4.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.6](https://github.com/markhaehnel/bambulab/compare/v0.4.5...v0.4.6) - 2024-10-21

### Other

- *(deps)* bump serde_json from 1.0.129 to 1.0.132 ([#40](https://github.com/markhaehnel/bambulab/pull/40))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).