### PR TITLE
chore: release v0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.7](https://github.com/markhaehnel/bambulab/compare/v0.4.6...v0.4.7) - 2024-10-28
+
+### Other
+
+- *(deps)* bump serde from 1.0.210 to 1.0.213 ([#43](https://github.com/markhaehnel/bambulab/pull/43))
+- *(deps)* bump tokio from 1.40.0 to 1.41.0 ([#44](https://github.com/markhaehnel/bambulab/pull/44))
+
 ## [0.4.6](https://github.com/markhaehnel/bambulab/compare/v0.4.5...v0.4.6) - 2024-10-21
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "bambulab"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "futures",
  "nanoid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bambulab"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 repository = "https://github.com/markhaehnel/bambulab"
 authors = ["Mark Hähnel <hello@markhaehnel.de>"]


### PR DESCRIPTION
## 🤖 New release
* `bambulab`: 0.4.6 -> 0.4.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.7](https://github.com/markhaehnel/bambulab/compare/v0.4.6...v0.4.7) - 2024-10-28

### Other

- *(deps)* bump serde from 1.0.210 to 1.0.213 ([#43](https://github.com/markhaehnel/bambulab/pull/43))
- *(deps)* bump tokio from 1.40.0 to 1.41.0 ([#44](https://github.com/markhaehnel/bambulab/pull/44))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).