### PR TITLE
chore: release v0.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.8](https://github.com/markhaehnel/bambulab/compare/v0.4.7...v0.4.8) - 2024-11-04
+
+### Other
+
+- *(deps)* bump serde from 1.0.213 to 1.0.214 ([#46](https://github.com/markhaehnel/bambulab/pull/46))
+
 ## [0.4.7](https://github.com/markhaehnel/bambulab/compare/v0.4.6...v0.4.7) - 2024-10-28
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "bambulab"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "futures",
  "nanoid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bambulab"
-version = "0.4.7"
+version = "0.4.8"
 edition = "2021"
 repository = "https://github.com/markhaehnel/bambulab"
 authors = ["Mark Hähnel <hello@markhaehnel.de>"]


### PR DESCRIPTION
## 🤖 New release
* `bambulab`: 0.4.7 -> 0.4.8 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.8](https://github.com/markhaehnel/bambulab/compare/v0.4.7...v0.4.8) - 2024-11-04

### Other

- *(deps)* bump serde from 1.0.213 to 1.0.214 ([#46](https://github.com/markhaehnel/bambulab/pull/46))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).