### PR TITLE
chore: release v0.4.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.10](https://github.com/markhaehnel/bambulab/compare/v0.4.9...v0.4.10) - 2024-11-19
+
+### Other
+
+- *(deps)* bump serde from 1.0.214 to 1.0.215 ([#51](https://github.com/markhaehnel/bambulab/pull/51))
+- *(deps)* bump serde_json from 1.0.132 to 1.0.133 ([#50](https://github.com/markhaehnel/bambulab/pull/50))
+
 ## [0.4.9](https://github.com/markhaehnel/bambulab/compare/v0.4.8...v0.4.9) - 2024-11-11
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "bambulab"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "futures",
  "nanoid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bambulab"
-version = "0.4.9"
+version = "0.4.10"
 edition = "2021"
 repository = "https://github.com/markhaehnel/bambulab"
 authors = ["Mark Hähnel <hello@markhaehnel.de>"]


### PR DESCRIPTION
## 🤖 New release
* `bambulab`: 0.4.9 -> 0.4.10 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.10](https://github.com/markhaehnel/bambulab/compare/v0.4.9...v0.4.10) - 2024-11-19

### Other

- *(deps)* bump serde from 1.0.214 to 1.0.215 ([#51](https://github.com/markhaehnel/bambulab/pull/51))
- *(deps)* bump serde_json from 1.0.132 to 1.0.133 ([#50](https://github.com/markhaehnel/bambulab/pull/50))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).