### PR TITLE
chore: release v0.4.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.12](https://github.com/markhaehnel/bambulab/compare/v0.4.11...v0.4.12) - 2024-12-23
+
+### Other
+
+- *(deps)* bump serde_json from 1.0.133 to 1.0.134 (#56)
+
 ## [0.4.11](https://github.com/markhaehnel/bambulab/compare/v0.4.10...v0.4.11) - 2024-12-17
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "bambulab"
-version = "0.4.11"
+version = "0.4.12"
 dependencies = [
  "futures",
  "nanoid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bambulab"
-version = "0.4.11"
+version = "0.4.12"
 edition = "2021"
 repository = "https://github.com/markhaehnel/bambulab"
 authors = ["Mark Hähnel <hello@markhaehnel.de>"]


### PR DESCRIPTION
## 🤖 New release
* `bambulab`: 0.4.11 -> 0.4.12 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.12](https://github.com/markhaehnel/bambulab/compare/v0.4.11...v0.4.12) - 2024-12-23

### Other

- *(deps)* bump serde_json from 1.0.133 to 1.0.134 (#56)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).