### PR TITLE
chore: release v0.4.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.13](https://github.com/markhaehnel/bambulab/compare/v0.4.12...v0.4.13) - 2024-12-30
+
+### Other
+
+- *(deps)* bump serde from 1.0.216 to 1.0.217 (#58)
+
 ## [0.4.12](https://github.com/markhaehnel/bambulab/compare/v0.4.11...v0.4.12) - 2024-12-23
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "bambulab"
-version = "0.4.12"
+version = "0.4.13"
 dependencies = [
  "futures",
  "nanoid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bambulab"
-version = "0.4.12"
+version = "0.4.13"
 edition = "2021"
 repository = "https://github.com/markhaehnel/bambulab"
 authors = ["Mark Hähnel <hello@markhaehnel.de>"]


### PR DESCRIPTION
## 🤖 New release
* `bambulab`: 0.4.12 -> 0.4.13 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.13](https://github.com/markhaehnel/bambulab/compare/v0.4.12...v0.4.13) - 2024-12-30

### Other

- *(deps)* bump serde from 1.0.216 to 1.0.217 (#58)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).