### PR TITLE
chore: release v0.4.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.17](https://github.com/markhaehnel/bambulab/compare/v0.4.16...v0.4.17) - 2025-02-05
+
+### Added
+
+- add feature toggle for tls verification (#71)
+- add basic TLS certificate validation (#67)
+
+### Other
+
+- *(deps)* bump serde_json from 1.0.137 to 1.0.138 (#68)
+
 ## [0.4.16](https://github.com/markhaehnel/bambulab/compare/v0.4.15...v0.4.16) - 2025-01-27
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "bambulab"
-version = "0.4.16"
+version = "0.4.17"
 dependencies = [
  "futures",
  "nanoid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bambulab"
-version = "0.4.16"
+version = "0.4.17"
 edition = "2021"
 repository = "https://github.com/markhaehnel/bambulab"
 authors = ["Mark Hähnel <hello@markhaehnel.de>"]


### PR DESCRIPTION



## 🤖 New release

* `bambulab`: 0.4.17

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.17](https://github.com/markhaehnel/bambulab/compare/v0.4.16...v0.4.17) - 2025-02-05

### Added

- add feature toggle for tls verification (#71)
- add basic TLS certificate validation (#67)

### Other

- *(deps)* bump serde_json from 1.0.137 to 1.0.138 (#68)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).