### PR TITLE
chore: release v0.4.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.18](https://github.com/markhaehnel/bambulab/compare/v0.4.17...v0.4.18) - 2025-02-24
+
+### Other
+
+- *(deps)* bump serde from 1.0.217 to 1.0.218 (#74)
+- *(deps)* bump serde_json from 1.0.138 to 1.0.139 (#73)
+- *(deps)* bump paho-mqtt from 0.13.0 to 0.13.1 (#72)
+
 ## [0.4.17](https://github.com/markhaehnel/bambulab/compare/v0.4.16...v0.4.17) - 2025-02-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "bambulab"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "futures",
  "nanoid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bambulab"
-version = "0.4.17"
+version = "0.4.18"
 edition = "2021"
 repository = "https://github.com/markhaehnel/bambulab"
 authors = ["Mark Hähnel <hello@markhaehnel.de>"]


### PR DESCRIPTION



## 🤖 New release

* `bambulab`: 0.4.17 -> 0.4.18 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.18](https://github.com/markhaehnel/bambulab/compare/v0.4.17...v0.4.18) - 2025-02-24

### Other

- *(deps)* bump serde from 1.0.217 to 1.0.218 (#74)
- *(deps)* bump serde_json from 1.0.138 to 1.0.139 (#73)
- *(deps)* bump paho-mqtt from 0.13.0 to 0.13.1 (#72)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).