### PR TITLE
chore: release v0.4.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.19](https://github.com/markhaehnel/bambulab/compare/v0.4.18...v0.4.19) - 2025-03-03
+
+### Other
+
+- *(deps)* bump serde_json from 1.0.139 to 1.0.140 ([#76](https://github.com/markhaehnel/bambulab/pull/76))
+
 ## [0.4.18](https://github.com/markhaehnel/bambulab/compare/v0.4.17...v0.4.18) - 2025-02-24
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "bambulab"
-version = "0.4.18"
+version = "0.4.19"
 dependencies = [
  "futures",
  "nanoid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bambulab"
-version = "0.4.18"
+version = "0.4.19"
 edition = "2021"
 repository = "https://github.com/markhaehnel/bambulab"
 authors = ["Mark Hähnel <hello@markhaehnel.de>"]


### PR DESCRIPTION



## 🤖 New release

* `bambulab`: 0.4.18 -> 0.4.19 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.19](https://github.com/markhaehnel/bambulab/compare/v0.4.18...v0.4.19) - 2025-03-03

### Other

- *(deps)* bump serde_json from 1.0.139 to 1.0.140 ([#76](https://github.com/markhaehnel/bambulab/pull/76))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).