### PR TITLE
chore: release v0.4.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.21](https://github.com/markhaehnel/bambulab/compare/v0.4.20...v0.4.21) - 2025-03-18
+
+### Other
+
+- *(deps)* bump tokio from 1.44.0 to 1.44.1 ([#81](https://github.com/markhaehnel/bambulab/pull/81))
+
 ## [0.4.20](https://github.com/markhaehnel/bambulab/compare/v0.4.19...v0.4.20) - 2025-03-16
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "bambulab"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "futures",
  "nanoid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bambulab"
-version = "0.4.20"
+version = "0.4.21"
 edition = "2021"
 repository = "https://github.com/markhaehnel/bambulab"
 authors = ["Mark Hähnel <hello@markhaehnel.de>"]


### PR DESCRIPTION



## 🤖 New release

* `bambulab`: 0.4.20 -> 0.4.21 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.21](https://github.com/markhaehnel/bambulab/compare/v0.4.20...v0.4.21) - 2025-03-18

### Other

- *(deps)* bump tokio from 1.44.0 to 1.44.1 ([#81](https://github.com/markhaehnel/bambulab/pull/81))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).