### PR TITLE
chore: release v0.4.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.23](https://github.com/markhaehnel/bambulab/compare/v0.4.22...v0.4.23) - 2025-04-07
+
+### Other
+
+- *(deps)* bump tokio from 1.44.1 to 1.44.2 ([#85](https://github.com/markhaehnel/bambulab/pull/85))
+
 ## [0.4.22](https://github.com/markhaehnel/bambulab/compare/v0.4.21...v0.4.22) - 2025-03-31
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "bambulab"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "futures",
  "nanoid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bambulab"
-version = "0.4.22"
+version = "0.4.23"
 edition = "2021"
 repository = "https://github.com/markhaehnel/bambulab"
 authors = ["Mark Hähnel <hello@markhaehnel.de>"]


### PR DESCRIPTION



## 🤖 New release

* `bambulab`: 0.4.22 -> 0.4.23 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.23](https://github.com/markhaehnel/bambulab/compare/v0.4.22...v0.4.23) - 2025-04-07

### Other

- *(deps)* bump tokio from 1.44.1 to 1.44.2 ([#85](https://github.com/markhaehnel/bambulab/pull/85))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).