### PR TITLE
Fix Clippy lint: inline serial in MQTT topic formats

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -48,8 +48,8 @@ impl Client {
         Self {
             host,
             access_code,
-            topic_device_request: format!("device/{}/request", &serial),
-            topic_device_report: format!("device/{}/report", &serial),
+            topic_device_request: format!("device/{serial}/request"),
+            topic_device_report: format!("device/{serial}/report"),
             serial,
             mqtt,
             stream,


### PR DESCRIPTION
### Motivation
- Clippy flagged redundant references and uninlined format arguments in the MQTT topic construction which caused the `lint` CI job to fail.

### Description
- Replace `format!("device/{}/request", &serial)` and `format!("device/{}/report", &serial)` with `format!("device/{serial}/request")` and `format!("device/{serial}/report")` to use inline format arguments.

### Testing
- Ran `cargo fmt --check --all`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a834efd325c8331a040fff526a64cb7)